### PR TITLE
Fix KCODE warning on Ruby 1.9

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 require 'rubygems'
 require 'rake/gempackagetask'
 require 'spec/rake/spectask'

--- a/init.rb
+++ b/init.rb
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 # Rails plugin init
 require 'yandex_inflect'
 

--- a/lib/yandex_inflect.rb
+++ b/lib/yandex_inflect.rb
@@ -1,6 +1,6 @@
-# -*- encoding: utf-8 -*- 
+# -*- encoding: utf-8 -*-
 
-$KCODE = 'u'
+$KCODE = 'u' if RUBY_VERSION < '1.9.0'
 
 $:.unshift(File.dirname(__FILE__)) unless
   $:.include?(File.dirname(__FILE__)) || $:.include?(File.expand_path(File.dirname(__FILE__)))

--- a/lib/yandex_inflect/version.rb
+++ b/lib/yandex_inflect/version.rb
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 module YandexInflect
   module VERSION #:nodoc:
     MAJOR = 0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 begin
   require 'spec'
 rescue LoadError


### PR DESCRIPTION
This commit fixes the following warning:

```
/Users/nebolsin/.rvm/gems/ruby-1.9.2-p290@fotoshkola3/gems/yandex_inflect-0.1.0/lib/yandex_inflect.rb:3: warning: variable $KCODE is no longer effective; ignored
```

and includes encoding headers in all ruby files.
